### PR TITLE
Verify that XSS vulnerability isn't actually an issue. (opencms-1017/18)

### DIFF
--- a/cms/cms_plugins.py
+++ b/cms/cms_plugins.py
@@ -6,6 +6,7 @@ from cms.plugin_base import CMSPluginBase, PluginMenuItem
 from cms.plugin_pool import plugin_pool
 from cms.utils.urlutils import admin_reverse
 from django.conf.urls import url
+from django.utils.html import conditional_escape
 from django.http import HttpResponseForbidden, HttpResponseBadRequest, HttpResponse
 from django.middleware.csrf import get_token
 from django.utils.translation import ugettext, ugettext_lazy as _, get_language
@@ -111,12 +112,14 @@ class AliasPlugin(CMSPluginBase):
             try:
                 plugin = CMSPlugin.objects.get(pk=pk)
             except CMSPlugin.DoesNotExist:
+                pk = conditional_escape(pk)
                 return HttpResponseBadRequest("plugin with id %s not found." % pk)
         if 'placeholder_id' in request.POST:
             pk = request.POST['placeholder_id']
             try:
                 placeholder = Placeholder.objects.get(pk=pk)
             except Placeholder.DoesNotExist:
+                pk = conditional_escape(pk)
                 return HttpResponseBadRequest("placeholder with id %s not found." % pk)
             if not placeholder.has_change_permission(request.user):
                 return HttpResponseBadRequest("You do not have enough permission to alias this placeholder.")

--- a/cms/cms_plugins.py
+++ b/cms/cms_plugins.py
@@ -6,7 +6,6 @@ from cms.plugin_base import CMSPluginBase, PluginMenuItem
 from cms.plugin_pool import plugin_pool
 from cms.utils.urlutils import admin_reverse
 from django.conf.urls import url
-from django.utils.html import conditional_escape
 from django.http import HttpResponseForbidden, HttpResponseBadRequest, HttpResponse
 from django.middleware.csrf import get_token
 from django.utils.translation import ugettext, ugettext_lazy as _, get_language
@@ -112,14 +111,12 @@ class AliasPlugin(CMSPluginBase):
             try:
                 plugin = CMSPlugin.objects.get(pk=pk)
             except CMSPlugin.DoesNotExist:
-                pk = conditional_escape(pk)
                 return HttpResponseBadRequest("plugin with id %s not found." % pk)
         if 'placeholder_id' in request.POST:
             pk = request.POST['placeholder_id']
             try:
                 placeholder = Placeholder.objects.get(pk=pk)
             except Placeholder.DoesNotExist:
-                pk = conditional_escape(pk)
                 return HttpResponseBadRequest("placeholder with id %s not found." % pk)
             if not placeholder.has_change_permission(request.user):
                 return HttpResponseBadRequest("You do not have enough permission to alias this placeholder.")

--- a/cms/tests/test_alias.py
+++ b/cms/tests/test_alias.py
@@ -47,6 +47,20 @@ class AliasTestCase(TransactionCMSTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "I'm the first", html=False)
 
+    def test_add_plugin_sanitise_error_response(self):
+        """
+        In theory it is possible to pass in values to the create_alias method within cms_plugins,
+        it is then used to query the database, which will throw a value error if the value sent is not an integer.
+        """
+        with self.login_user_context(self.get_superuser()):
+            self.assertRaises(
+                ValueError,
+                self.client.post,
+                admin_reverse('cms_create_alias'),
+                {'plugin_id': "<script>alert('Attack!')</script>"}
+            )
+
+
     def test_alias_recursion(self):
         page_en = api.create_page(
             "Alias plugin",


### PR DESCRIPTION
## Description
https://github.com/adam-murray/django-cms/pull/5/files

When a CMSPlugin Alias is created, a post request is sent which includes the ID of a CMSPlugin, this is not sanitised and thus has been flagged, I have added a test to prove that a TypeError is thrown anyway if anything other than an integer is passed in. The ORM also has additional levels of validation.

https://jiraagile.bip.uk.fid-intl.com/browse/OPENCMS-1017
https://jiraagile.bip.uk.fid-intl.com/browse/OPENCMS-1018